### PR TITLE
BUG: Fix git_protocol variable.

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -1,14 +1,3 @@
-
-#-----------------------------------------------------------------------------
-# Git protocol option
-#-----------------------------------------------------------------------------
-option(Slicer_USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
-
-set(git_protocol "git")
-if(NOT Slicer_USE_GIT_PROTOCOL)
-  set(git_protocol "http")
-endif()
-
 #-----------------------------------------------------------------------------
 # Enable and setup External project global properties
 #-----------------------------------------------------------------------------

--- a/SuperBuild/External_ITKBoneMorphometry.cmake
+++ b/SuperBuild/External_ITKBoneMorphometry.cmake
@@ -13,7 +13,7 @@ set(${proj}_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 set(${proj}_GIT_TAG aad1ddc651ad014ac6f91222790f5bfd32d229dc)
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
   GIT_TAG ${${proj}_GIT_TAG}
   SOURCE_DIR ${proj}
   BINARY_DIR ${${proj}_BINARY_DIR}

--- a/SuperBuild/External_ITKTextureFeature.cmake
+++ b/SuperBuild/External_ITKTextureFeature.cmake
@@ -13,7 +13,7 @@ set(${proj}_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 set(${proj}_GIT_TAG 9eaa9a533b21f1c614647487e409619165752746)
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}
-  GIT_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
   GIT_TAG ${${proj}_GIT_TAG}
   SOURCE_DIR ${proj}
   BINARY_DIR ${${proj}_BINARY_DIR}


### PR DESCRIPTION
Current variable git_protocol is empty, when slicer
builds the extension using EXTENSION_SOURCE_DIRS

This fixes it using ${EP_GIT_PROTOCOL} instead.