### PR TITLE
COMP: Fix build against ITKv5

### DIFF
--- a/ComputeGLCMFeatures/ComputeGLCMFeatures.cxx
+++ b/ComputeGLCMFeatures/ComputeGLCMFeatures.cxx
@@ -73,14 +73,14 @@ int DoIt( int argc, char * argv[] )
   filter->SetPixelValueMinMax(pixelIntensityMin, pixelIntensityMax);
 
   typename FilterType::FeatureNameVectorPointer requestedFeatures = FilterType::FeatureNameVector::New();
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::Energy);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::Entropy);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::Correlation);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::InverseDifferenceMoment);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::Inertia);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::ClusterShade);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::ClusterProminence);
-  requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::HaralickCorrelation);
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::Energy));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::Entropy));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::Correlation));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::InverseDifferenceMoment));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::Inertia));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::ClusterShade));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::ClusterProminence));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::TextureFeaturesFilterType::HaralickCorrelation));
   filter->SetRequestedFeatures(requestedFeatures);
 
   filter->Update();

--- a/ComputeGLRLMFeatures/ComputeGLRLMFeatures.cxx
+++ b/ComputeGLRLMFeatures/ComputeGLRLMFeatures.cxx
@@ -74,16 +74,16 @@ int DoIt( int argc, char * argv[] )
   filter->SetDistanceValueMinMax(distanceMin, distanceMax);
 
   typename FilterType::FeatureNameVectorPointer requestedFeatures = FilterType::FeatureNameVector::New();
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::ShortRunEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::LongRunEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::GreyLevelNonuniformity);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::RunLengthNonuniformity);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::LowGreyLevelRunEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::HighGreyLevelRunEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::ShortRunLowGreyLevelEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::ShortRunHighGreyLevelEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::LongRunLowGreyLevelEmphasis);
-  requestedFeatures->push_back(FilterType::RunLengthFeaturesFilterType::LongRunHighGreyLevelEmphasis);
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::ShortRunEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::LongRunEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::GreyLevelNonuniformity));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::RunLengthNonuniformity));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::LowGreyLevelRunEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::HighGreyLevelRunEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::ShortRunLowGreyLevelEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::ShortRunHighGreyLevelEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::LongRunLowGreyLevelEmphasis));
+  requestedFeatures->push_back(static_cast<uint8_t>(FilterType::RunLengthFeaturesFilterType::LongRunHighGreyLevelEmphasis));
   filter->SetRequestedFeatures(requestedFeatures);
 
   filter->Update();


### PR DESCRIPTION
See https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md#strongly-typed-enumerations

This commit fixes error like the following:
```
  /tmp/BoneTextureExtension/ComputeGLCMFeatures/ComputeGLCMFeatures.cxx:76:3: error: no matching function for call to ‘itk::VectorContainer<unsigned char, unsigned char>::push_back(const TextureFeatureEnum&)’
     requestedFeatures->push_back(FilterType::TextureFeaturesFilterType::Energy);
     ^
```