### PR TITLE
ENH: Update ITKBoneMorphometry

### DIFF
--- a/SuperBuild/External_ITKBoneMorphometry.cmake
+++ b/SuperBuild/External_ITKBoneMorphometry.cmake
@@ -10,7 +10,7 @@ ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj
 set(${proj}_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
 # disable-wrapping 2016-10-24
-set(${proj}_GIT_TAG ec43e67b41d20e62a62f8ce50bc6390f6fadb92e)
+set(${proj}_GIT_TAG 7d4314f12a4682b2d995a628610eb7986d2e55de)
 ExternalProject_Add(${proj}
   ${${proj}_EP_ARGS}
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git


### PR DESCRIPTION
List of changes:

```
$ git shortlog ec43e67..7d4314f --no-merges
Hans Johnson (6):
      ENH: Add .gitattributes to allow running ITK clang-formatting scripts
      STYLE: Use override statements for C++11
      STYLE: Use auto for variable type matches the type of the initializer expression
      DOC: Update copyright assignment to NumFOCUS
      ENH: Set ITKGitTag to v5.1rc02 for azure CI
      ENH: Prefer https vs http for ctest submission.
```