### PR TITLE
FIX: Missing color maps in output.

### DIFF
--- a/ComputeBMFeatureMaps/ComputeBMFeatureMaps.cxx
+++ b/ComputeBMFeatureMaps/ComputeBMFeatureMaps.cxx
@@ -85,7 +85,7 @@ int DoIt( int argc, char * argv[] )
   postProcessingFilter->Update();
   
   itk::MetaDataDictionary dictionary;
-  itk::EncapsulateMetaData<float>(dictionary,"DWMRI_b-value",1.0);
+  itk::EncapsulateMetaData<std::string>(dictionary,"DWMRI_b-value","1.0");
   itk::EncapsulateMetaData<std::string>(dictionary,"modality","DWMRI");
   postProcessingFilter->GetOutput()->SetMetaDataDictionary(dictionary);
 

--- a/ComputeGLCMFeatureMaps/ComputeGLCMFeatureMaps.cxx
+++ b/ComputeGLCMFeatureMaps/ComputeGLCMFeatureMaps.cxx
@@ -81,7 +81,7 @@ int DoIt( int argc, char * argv[] )
   filter->Update();
 
   itk::MetaDataDictionary dictionary;
-  itk::EncapsulateMetaData<float>(dictionary,"DWMRI_b-value",1.0);
+  itk::EncapsulateMetaData<std::string>(dictionary,"DWMRI_b-value","1.0");
   itk::EncapsulateMetaData<std::string>(dictionary,"modality","DWMRI");
   filter->GetOutput()->SetMetaDataDictionary(dictionary);
 

--- a/ComputeGLRLMFeatureMaps/ComputeGLRLMFeatureMaps.cxx
+++ b/ComputeGLRLMFeatureMaps/ComputeGLRLMFeatureMaps.cxx
@@ -83,7 +83,7 @@ int DoIt( int argc, char * argv[] )
   filter->Update();
   
   itk::MetaDataDictionary dictionary;
-  itk::EncapsulateMetaData<float>(dictionary,"DWMRI_b-value",1.0);
+  itk::EncapsulateMetaData<std::string>(dictionary,"DWMRI_b-value","1.0");
   itk::EncapsulateMetaData<std::string>(dictionary,"modality","DWMRI");
   filter->GetOutput()->SetMetaDataDictionary(dictionary);
 


### PR DESCRIPTION
Issue is caused by ITK `NrrdIO` being unable to stringify entries in `MetaDataDictionary` not defined in the nrrd standard (and `DWMRI_b-value` is not); so an empty entry would be created in the temporary nhdr file used to transfer mrml node to the CLI. 

```
DWMRI_b-value:=
modality:=DWMRI
```

That missing value caused various issues in loading the temporary file when transfering back to the MRML node, so some (but not all) values in the MRML node are missing, hiding the issue.

So it seems that ad-hoc properties like this must to be stringified before passing to `MetaDataDictonary`, at least for the nrrd writer. Similarly the nrrd reader can only dynamically read strings.

https://github.com/Kitware/ITK/blob/8aed68490b733ba45b36b2e8e84e99980db45948/Modules/IO/NRRD/src/itkNrrdImageIO.cxx#L1065-L1072

I'm not sure what change caused this to suddenly break... Best I can tell, that's been the behavior since 2007, so why was it working before!? This approach seems more robust anyway, especially given `DWMRI_b-value` is a constant `1.0`.