### PR TITLE
Resolve Serialization Issues

### DIFF
--- a/BoneTexture/Resources/UI/BoneTexture.ui
+++ b/BoneTexture/Resources/UI/BoneTexture.ui
@@ -646,7 +646,7 @@
             <set>QAbstractItemView::NoEditTriggers</set>
            </property>
            <property name="selectionMode">
-            <enum>QAbstractItemView::NoSelection</enum>
+            <enum>QAbstractItemView::ExtendedSelection</enum>
            </property>
            <attribute name="horizontalHeaderCascadingSectionResizes">
             <bool>true</bool>

--- a/BoneTextureSerializer/BoneTextureSerializer.py
+++ b/BoneTextureSerializer/BoneTextureSerializer.py
@@ -518,9 +518,9 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
                                None,
                                param,
                                wait_for_completion=True)
-                slicer.mrmlScene.RemoveNode(storageforCSV["GLCM"])
-                slicer.mrmlScene.RemoveNode(storageforCSV["GLRLM"])
-                slicer.mrmlScene.RemoveNode(storageforCSV["BM"])
+
+                for storageNode in storageforCSV.values():
+                    slicer.mrmlScene.RemoveNode(storageNode)
 
             slicer.mrmlScene.RemoveNode(inputScan)
             slicer.mrmlScene.RemoveNode(inputSegmentation)

--- a/BoneTextureSerializer/BoneTextureSerializer.py
+++ b/BoneTextureSerializer/BoneTextureSerializer.py
@@ -136,7 +136,10 @@ class BoneTextureSerializerWidget(ScriptedLoadableModuleWidget):
         self.outputFolderDirectoryButton = self.logic.get("OutputFolderDirectoryButton")
         self.separateFeaturesCheckBox = self.logic.get("separateFeaturesCheckBox")
         self.saveAsCSVCheckBox = self.logic.get("saveAsCSVCheckBox")
+        self.writeCSVHeaderCheckBox = self.logic.get("writeCSVHeaderCheckBox")
 
+        # there's probably a way to do this in the .ui file...
+        self.saveAsCSVCheckBox.stateChanged.connect(self.writeCSVHeaderCheckBox.setEnabled)
 
         # -------------------------------------------------------------------- #
         # ---------------------------- Connections --------------------------- #
@@ -212,7 +215,8 @@ class BoneTextureSerializerWidget(ScriptedLoadableModuleWidget):
                                     self.BMFeaturesValueDict,
                                     self.outputFolderDirectoryButton.directory,
                                     self.separateFeaturesCheckBox.isChecked(),
-                                    self.saveAsCSVCheckBox.isChecked())
+                                    self.saveAsCSVCheckBox.isChecked(),
+                                    self.writeCSVHeaderCheckBox.isChecked())
 
         # ---------------- Export Collapsible Button -------------------- #
 
@@ -405,7 +409,7 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
                          BMFeaturesValueDict,
                          outputDirectory,
                          saparateFeatureMaps,
-                         saveAsCSV):
+                         saveAsCSV, writeCSVHeader):
 
         if not (computeGLCMFeatures or computeGLRLMFeatures or computeBMFeatures):
             slicer.util.warningDisplay("Please select at least one type of features to compute")
@@ -427,6 +431,7 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
             storageforCSV = {}
             if saveAsCSV and (not os.path.exists(os.path.join(outputDirectory , "CSVfeatureMaps"))):
                 os.makedirs(os.path.join(outputDirectory , "CSVfeatureMaps"))
+
             if computeGLCMFeatures:
                 volumeNode = self.computeSingleColormap(inputScan,
                                                         inputSegmentation,
@@ -444,10 +449,7 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
                 else:
                     slicer.util.saveNode(volumeNode, os.path.join(outputDirectory , case.caseID + "_GLCMFeatureMap.nhdr"))
 
-                if saveAsCSV:
-                    storageforCSV["GLCM"] = volumeNode
-                else:
-                    slicer.mrmlScene.RemoveNode(volumeNode)
+                storageforCSV["GLCM"] = volumeNode
 
             if computeGLRLMFeatures:
                 volumeNode = self.computeSingleColormap(inputScan,
@@ -466,10 +468,7 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
                 else:
                     slicer.util.saveNode(volumeNode, os.path.join(outputDirectory , case.caseID + "_GLRLMFeatureMap.nhdr"))
 
-                if saveAsCSV:
-                    storageforCSV["GLRLM"] = volumeNode
-                else:
-                    slicer.mrmlScene.RemoveNode(volumeNode)
+                storageforCSV["GLRLM"] = volumeNode
 
             if computeBMFeatures:
                 volumeNode = self.computeSingleColormap(inputScan,
@@ -480,52 +479,113 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
                 if saparateFeatureMaps:
                     param = dict()
                     param["inputVolume"] = volumeNode
-                    param["outputFileBaseName"] = os.path.join(outputDirectory, case.caseID + "_BMFeatureMap")
+                    param["outputFileBaseName"] = os.path.join(outputDirectory,
+                                                               case.caseID + "_BMFeatureMap")
                     slicer.cli.run(slicer.modules.separatevectorimage,
                                    None,
                                    param,
                                    wait_for_completion=True)
                 else:
                     slicer.util.saveNode(volumeNode,
-                                         os.path.join(outputDirectory, case.caseID + "_BMFeatureMap.nhdr"))
+                                         os.path.join(outputDirectory,
+                                                      case.caseID + "_BMFeatureMap.nhdr"))
 
-                if saveAsCSV:
-                    storageforCSV["BM"] = volumeNode
-                else:
-                    slicer.mrmlScene.RemoveNode(volumeNode)
+                storageforCSV["BM"] = volumeNode
+
+            import csv
 
             if saveAsCSV:
-                param = dict()
-                param["inputMask"] = inputSegmentation
-                param["outputFileBaseName"] = os.path.join(outputDirectory , "CSVfeatureMaps" , case.caseID + "_FeatureMap.csv")
-                if computeGLCMFeatures:
-                    param["inputVolume"] = storageforCSV["GLCM"]
-                    if computeGLRLMFeatures:
-                        param["secondInputVolume"] = storageforCSV["GLRLM"]
-                        if computeBMFeatures:
-                            param["thirdInputVolume"] = storageforCSV["BM"]
-                            param["predefineTitle"] = True
-                    elif computeBMFeatures:
-                        param["secondInputVolume"] = storageforCSV["BM"]
-                elif computeGLRLMFeatures:
-                    param["inputVolume"] = storageforCSV["GLRLM"]
-                    if computeBMFeatures:
-                        param["secondInputVolume"] = storageforCSV["BM"]
-                else:
-                    param["inputVolume"] = storageforCSV["BM"]
+                tempdir = slicer.util.tempDirectory(key='BoneTextureSerializer')
 
-                slicer.cli.run(slicer.modules.savevectorimageascsv,
-                               None,
-                               param,
-                               wait_for_completion=True)
+                readers = []
+                headings = []
+
+                if computeGLCMFeatures:
+                    name = os.path.join(tempdir, case.caseID + '_GLCM.csv')
+                    slicer.cli.run(
+                        slicer.modules.savevectorimageascsv,
+                        None,
+                        {
+                            'inputMask': inputSegmentation,
+                            'inputVolume': storageforCSV['GLCM'],
+                            'outputFileBaseName': name,
+                        },
+                        wait_for_completion=True,
+                    )
+                    readers.append(csv.reader(open(name)))  # going to close these
+                    headings.append(self.CFeatures)
+
+                if computeGLRLMFeatures:
+                    name = os.path.join(tempdir, case.caseID + '_GLRLM.csv')
+                    slicer.cli.run(
+                        slicer.modules.savevectorimageascsv,
+                        None,
+                        {
+                            'inputMask': inputSegmentation,
+                            'inputVolume': storageforCSV['GLRLM'],
+                            'outputFileBaseName': name,
+                        },
+                        wait_for_completion=True,
+                    )
+                    readers.append(csv.reader(open(name)))  # going to close these
+                    headings.append(self.RLFeatures)
+
+                if computeBMFeatures:
+                    name = os.path.join(tempdir, case.caseID + '_BM.csv')
+                    slicer.cli.run(
+                        slicer.modules.savevectorimageascsv,
+                        None,
+                        {
+                            'inputMask': inputSegmentation,
+                            'inputVolume': storageforCSV['BM'],
+                            'outputFileBaseName': name,
+                        },
+                        wait_for_completion=True,
+                    )
+                    readers.append(csv.reader(open(name)))  # going to close these
+                    headings.append(self.BMFeatures)
+
+                # now we need to merge the csvs, and add a header.
+                # since they were all generated with the same segmentation,
+                # we can assume the order of the files is the same.
+                # so we just need to grab the x,y,z coords and each of the values,
+                # then save those to one csv in the output directory.
+
+                outPath = os.path.join(
+                    outputDirectory,
+                    "CSVfeatureMaps",
+                    case.caseID + "_FeatureMap.csv",
+                )
+
+
+                with open(outPath, 'w') as outFile:
+                    writer = csv.writer(outFile)
+
+                    if writeCSVHeader:
+                        allHeadings = [field for heading in headings for field in heading]
+                        writer.writerow(('X', 'Y', 'Z', *allHeadings))
+
+                    for rows in zip(*readers):
+                        # Shouldn't be needed... but just in case we didn't actually
+                        # compute anything.
+                        x = y = z = None
+
+                        allData = []
+                        for row in rows:
+                            x, y, z, *data = row
+                            allData.extend(data)
+
+                        writer.writerow((x, y, z, *allData))
+
+                readers.clear()  # triggers deletion and closes the file handles
 
                 for storageNode in storageforCSV.values():
                     slicer.mrmlScene.RemoveNode(storageNode)
 
-            slicer.mrmlScene.RemoveNode(inputScan)
-            slicer.mrmlScene.RemoveNode(inputSegmentation)
+                slicer.mrmlScene.RemoveNode(inputScan)
+                slicer.mrmlScene.RemoveNode(inputSegmentation)
 
-        self.renameSeparatedFeatures(outputDirectory)
+                self.renameSeparatedFeatures(outputDirectory)
 
     def computeSingleColormap(self,
                               inputScan,

--- a/BoneTextureSerializer/BoneTextureSerializer.py
+++ b/BoneTextureSerializer/BoneTextureSerializer.py
@@ -200,7 +200,7 @@ class BoneTextureSerializerWidget(ScriptedLoadableModuleWidget):
                                    self.GLCMFeaturesValueDict,
                                    self.GLRLMFeaturesValueDict,
                                    self.BMFeaturesValueDict,
-                                   self.outputFolderDirectoryButton.directory.encode('utf-8'))
+                                   self.outputFolderDirectoryButton.directory)
 
     def onComputeColormaps(self):
         self.logic.computeColormaps(self.caseDict,
@@ -210,7 +210,7 @@ class BoneTextureSerializerWidget(ScriptedLoadableModuleWidget):
                                     self.GLCMFeaturesValueDict,
                                     self.GLRLMFeaturesValueDict,
                                     self.BMFeaturesValueDict,
-                                    self.outputFolderDirectoryButton.directory.encode('utf-8'),
+                                    self.outputFolderDirectoryButton.directory,
                                     self.separateFeaturesCheckBox.isChecked(),
                                     self.saveAsCSVCheckBox.isChecked())
 

--- a/BoneTextureSerializer/BoneTextureSerializer.py
+++ b/BoneTextureSerializer/BoneTextureSerializer.py
@@ -261,7 +261,7 @@ class BoneTextureSerializerLogic(ScriptedLoadableModuleLogic):
     def isClose(self, a, b, rel_tol=0.0, abs_tol=0.0):
         for i in range(len(a)):
             if not (abs(a[i] - b[i]) <= max(rel_tol * max(abs(a[i]), abs(b[i])), abs_tol)):
-                return flase
+                return False
         return True
 
     def findWidget(self, widget, objectName):

--- a/BoneTextureSerializer/Resources/UI/BoneTextureSerializer.ui
+++ b/BoneTextureSerializer/Resources/UI/BoneTextureSerializer.ui
@@ -524,6 +524,19 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="writeCSVHeaderCheckBox">
+        <property name="text">
+         <string>Write CSV Header</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="separateFeaturesCheckBox">
         <property name="text">


### PR DESCRIPTION
Resolves #21 

> 1. When I`m using the Bonetexture Serializer, if I check the box: [] export as csv , the software does not run the analysis. If the box is unchecked It runs normally.

There were some logic errors regarding storage nodes and `str`/`bytes`. See fd0737d and 925d98f

> 2. the name of the variables are not shown in the CSV file generated by step 1.

The existing behavior of the csv serialization is strongly engrained in `SaveVectorImageAsCSV.cxx`; the header is only saved if all three feature sets are computed. Rather than completely reimplementing `SaveVectorImageAsCSV.cxx`, I instead save each feature set results to its own file in the slicer temp directory; then I merge these in python. Since they are all generated in the same order, it's sufficient to naively zip through them, so I don't expect speed to be an issue. If it is, then reimplementing `SaveVectorImageAsCSV.cxx` to be more dynamic would probably be the best next step. See 0f6091b

> 3. When I'm using the Bonetexture (for a single case) is not possible to select more than one variable result (to do a CTRL C , CTRL V). I need to do one by one or use the "save table" option.

To allow this I enable `ExtendedSelection` on the table widget and install an event filter to catch the copy keyboard shortcut. The copy text is in tsv format, which most spreadsheet editors seem to pick up. I've tested in Google Docs and LibreOffice Calc; online reading suggests this should also work in Excel but I haven't tested it. See 5b47e76