### PR TITLE
Support Slicer >= 5.2 and ITK >= 5.3

### DIFF
--- a/ComputeBMFeatureMaps/CMakeLists.txt
+++ b/ComputeBMFeatureMaps/CMakeLists.txt
@@ -24,7 +24,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   BoneMorphometry
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/ComputeBMFeatures/CMakeLists.txt
+++ b/ComputeBMFeatures/CMakeLists.txt
@@ -24,7 +24,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   BoneMorphometry
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/ComputeGLCMFeatureMaps/CMakeLists.txt
+++ b/ComputeGLCMFeatureMaps/CMakeLists.txt
@@ -24,7 +24,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   TextureFeatures
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/ComputeGLCMFeatures/CMakeLists.txt
+++ b/ComputeGLCMFeatures/CMakeLists.txt
@@ -23,7 +23,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/ComputeGLRLMFeatureMaps/CMakeLists.txt
+++ b/ComputeGLRLMFeatureMaps/CMakeLists.txt
@@ -24,7 +24,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   TextureFeatures
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/ComputeGLRLMFeatures/CMakeLists.txt
+++ b/ComputeGLRLMFeatures/CMakeLists.txt
@@ -23,7 +23,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/CreateLabelMapFromCSV/CMakeLists.txt
+++ b/CreateLabelMapFromCSV/CMakeLists.txt
@@ -23,7 +23,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/SaveVectorImageAsCSV/CMakeLists.txt
+++ b/SaveVectorImageAsCSV/CMakeLists.txt
@@ -23,7 +23,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/SeparateVectorImage/CMakeLists.txt
+++ b/SeparateVectorImage/CMakeLists.txt
@@ -23,7 +23,13 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.9 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(ITK_VERSION VERSION_GREATER_EQUAL "5.3")
+  foreach(factory_uc IN ITEMS "IMAGEIO" "MESHIO" "TRANSFORMIO")
+    set(ITK_NO_${factory_uc}_FACTORY_REGISTER_MANAGER 1)
+  endforeach()
+else()
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull-request is intended to fix the extensionbuild and ultimately address this issue:
* https://github.com/Kitware/BoneTextureExtension/issues/43

### Fix use of deprecated `ITK_NO_IO_FACTORY_REGISTER_MANAGER`

As depicted at https://github.com/InsightSoftwareConsortium/ITK/blob/4f68349370abaaee7ee9799a19c4d99f3d914aec/CMake/ITKFactoryRegistration.cmake#L198 and https://github.com/InsightSoftwareConsortium/ITK/pull/3153, using `ITK_NO_IO_FACTORY_REGISTER_MANAGER` is now deprecated.

This approach allows to maintain backwards compatibility for building against older ITK while supporting building against ITK >= 5.3.